### PR TITLE
Tests for coroutine

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -17,7 +17,9 @@ require('./promiseFns/reduce')(Bluebird);
 require('./promiseFns/throw')(Bluebird);
 require('./promiseFns/catchReturn')(Bluebird);
 require('./promiseFns/catchThrow')(Bluebird);
+require('./promiseFns/caught')(Bluebird);
 require('./promiseFns/coroutine')(Bluebird);
+require('./promiseFns/cast')(Bluebird);
 
 module.exports = Bluebird;
 

--- a/promiseFns/cast.js
+++ b/promiseFns/cast.js
@@ -1,0 +1,3 @@
+module.exports = (Bluebird) => {
+    Bluebird.cast = Promise.resolve;
+};

--- a/promiseFns/caught.js
+++ b/promiseFns/caught.js
@@ -1,0 +1,3 @@
+module.exports = (Bluebird) => {
+    Bluebird.prototype.caught = Promise.prototype.catch;
+};

--- a/promiseFns/coroutine.js
+++ b/promiseFns/coroutine.js
@@ -1,16 +1,58 @@
+const util = require("./util");
+
+async function runGenerator(generator, args, thisContext) { 
+    let iterator = generator.apply(thisContext, args);
+
+    const next = ({ value, error }) => {
+        if (error) {
+            return iterator.throw(error);
+        }
+        else {
+            return iterator.next(value);
+        }
+    }
+
+    let value, done, error;
+    do {
+        ({ value, done, error } = next({ value, error }));
+
+        if (Array.isArray(value)) {
+            value = Promise.all(value);
+        }
+        else if (!util.isPromise(value)) {
+            error = new TypeError('OMG, Not a promise.');
+        }
+
+        try {
+            value = await value;
+        }
+        catch (ex) {
+            value = undefined;
+            error = ex;
+        }
+    } while (!done);
+
+    return value;
+}
+
 module.exports = (Bluebird) => {
     Bluebird.coroutine = function(generator) {
-        return async function(...args) {
-            let iterator = generator.apply(null, args);
+        return (...args) => {
+            let result;
 
-            let value, done;
-            do {
-                ({ value, done } = iterator.next(value));
+            try {
+                result = runGenerator(generator, args, this);
+            }
+            catch (ex) {
+                return Bluebird.reject(ex);
+            }
 
-                value = await value;
-            } while (!done);
-
-            return value;
+            // wrap in Promise.resolve so this returns a "fake bluebird" promise
+            return Bluebird.resolve(result);
         }
+    }
+
+    Bluebird.spawn = function(generator) {
+        return Bluebird.coroutine(generator)();
     }
 };

--- a/promiseFns/join.js
+++ b/promiseFns/join.js
@@ -1,10 +1,14 @@
 module.exports = (Bluebird) => {
     Bluebird.join = async function join(...args) {
-        var last = args.pop();
-        if(typeof last !== "function") {
-            throw new TypeError("Promise.join's last parameter should be a function")
+        const last = args.slice(-1)[0];
+
+        if (typeof last === "function") {
+            const otherArgs = args.slice(0, -1);
+            let values = await Bluebird.all(otherArgs);
+            return await last(...values);
         }
-        var values = await Bluebird.all(args)
-        return await last(...values);
+        else {
+            return await Bluebird.all(args);
+        }
     };
 };

--- a/promiseFns/util.js
+++ b/promiseFns/util.js
@@ -1,5 +1,6 @@
 module.exports = {
-    throttle
+    throttle,
+    isPromise
 };
 
 
@@ -31,4 +32,8 @@ function throttle(fn, concurrency = 20) {
         });
         return worker;
     }
+}
+
+function isPromise(obj) {
+    return obj && obj.then && (typeof(obj.then) === 'function');
 }

--- a/tests/coroutine.js
+++ b/tests/coroutine.js
@@ -1,20 +1,760 @@
 "use strict";
-
-var assert = require("assert");
-var testUtils = require("./helpers/util.js");
-
+const assert = require("assert");
+const testUtils = require("./helpers/util.js");
 const Promise = require("../promise.js");
 
-const MAGIC_NUMBER = 5578;
 
-describe('coroutine', () => {
-    it('works', async () => {
-        let result = await Promise.coroutine(function* () {
-            let answer = yield new Promise((resolve) => setTimeout(() => resolve(MAGIC_NUMBER), 500));
+// Things I added to make the tests run
+testUtils.addDeferred(Promise);
+Promise.TypeError = TypeError;
 
-            return answer + 1;
-        })();
+//original tests
+function get(arg) {
+    return {
+        then: function(ful, rej) {
+            ful(arg)
+        }
+    }
+}
 
-        assert.equal(result, MAGIC_NUMBER + 1);
+function fail(arg) {
+    return {
+        then: function(ful, rej) {
+            rej(arg)
+        }
+    };
+}
+
+var error = new Error("asd");
+
+describe("yielding", function() {
+
+    specify("non-promise should throw", function() {
+        return Promise.coroutine(function*(){
+
+            var a = yield {};
+            assert.fail();
+            return 4;
+
+        })().then(assert.fail).caught(function(e){
+            assert(e instanceof TypeError);
+        });
+    });
+
+    specify("an array should implicitly Promise.all them", function() {
+        var a = Promise.defer();
+        var ap = a.promise;
+        var b = Promise.defer();
+        var bp = b.promise;
+        var c = Promise.defer();
+        var cp = c.promise;
+
+
+        setTimeout(function(){
+            a.fulfill(1);
+            b.fulfill(2);
+            c.fulfill(3);
+        }, 1);
+        return Promise.coroutine(function*(){
+            return yield [ap, bp, cp];
+        })().then(function(r) {
+            //.spread will also implicitly use .all() so that cannot be used here
+            var a = r[0]; var b = r[1]; var c = r[2];
+            assert(a === 1);
+            assert(b === 2);
+            assert(c === 3);
+        });
+    });
+
+    specify("non-promise should throw but be catchable", function() {
+
+        return Promise.coroutine(function*(){
+            try {
+                var a = yield {};
+                assert.fail();
+            }
+            catch (e){
+                assert(e instanceof TypeError);
+                return 4;
+            }
+
+        })().then(function(val){
+            assert.equal(val, 4);
+        });
+    });
+
+    specify("yielding a function should not call the function", function() {
+        let functionWasCalled = false;
+        return Promise.coroutine(function*(){
+            try {
+                yield (function() {functionWasCalled = true;});
+            } 
+            catch(e){
+                assert(e instanceof TypeError);
+                assert.equal(functionWasCalled, false);
+                return 4;
+            }
+        })().then(function(val){
+            assert.equal(val, 4);
+        });
     });
 });
+
+describe("thenables", function(){
+
+    specify("when they fulfill, the yielded value should be that fulfilled value", function(){
+
+        return Promise.coroutine(function*(){
+
+            var a = yield get(3);
+            assert.equal(a, 3);
+            return 4;
+
+        })().then(function(arg){
+            assert.equal(arg, 4);
+        });
+
+    });
+
+
+    specify("when they reject, and the generator doesn't have try.caught, it should immediately reject the promise", function(){
+
+        return Promise.coroutine(function*(){
+            var a = yield fail(error);
+            assert.fail();
+
+        })().then(assert.fail).then(assert.fail, function(e){
+            assert.equal(e, error);
+        });
+
+    });
+
+    specify("when they reject, and the generator has try.caught, it should continue working normally", function(){
+
+        return Promise.coroutine(function*(){
+            try {
+                var a = yield fail(error);
+            }
+            catch (e) {
+                return e;
+            }
+            assert.fail();
+
+        })().then(function(v){
+            assert.equal(v, error);
+        });
+
+    });
+
+    specify("when they fulfill but then throw, it should become rejection", function(){
+
+        return Promise.coroutine(function*(){
+            var a = yield get(3);
+            assert.equal(a, 3);
+            throw error;
+        })().then(assert.fail, function(e){
+            assert.equal(e, error);
+        });
+    });
+});
+
+describe("yield loop", function(){
+
+    specify("should work", function(){
+        return Promise.coroutine(function* () {
+            var a = [1,2,3,4,5];
+
+            for (var i = 0, len = a.length; i < len; ++i) {
+                a[i] = yield get(a[i] * 2);
+            }
+
+            return a;
+        })().then(function(arr){
+            assert.deepEqual([2,4,6,8,10], arr);
+        });
+    });
+
+    specify("inside yield should work", function(){
+        return Promise.coroutine(function *() {
+            var a = [1,2,3,4,5];
+
+            return yield Promise.all(a.map(function(v){
+                return Promise.coroutine(function *() {
+                    return yield get(v*2);
+                })();
+            }));
+        })().then(function(arr){
+            assert.deepEqual([2,4,6,8,10], arr);
+        });
+    });
+
+    specify("with simple map should work", function(){
+        return Promise.coroutine(function *() {
+            var a = [1,2,3,4,5];
+
+            return yield Promise.map(a, function(v){
+                return Promise.cast(get(v*2));
+            });
+        })().then(function(arr){
+            assert.deepEqual([2,4,6,8,10], arr);
+        });
+    });
+
+});
+
+
+describe("Promise.coroutine", function() {
+    describe("thenables", function() {
+        specify("when they fulfill, the yielded value should be that fulfilled value", function(){
+
+            return Promise.coroutine(function*(){
+
+                var a = yield get(3);
+                assert.equal(a, 3);
+                return 4;
+
+            })().then(function(arg){
+                assert.equal(arg, 4);
+            });
+
+        });
+
+
+        specify("when they reject, and the generator doesn't have try.caught, it should immediately reject the promise", function(){
+
+            return Promise.coroutine(function*(){
+                var a = yield fail(error);
+                assert.fail();
+
+            })().then(assert.fail).then(assert.fail, function(e){
+                assert.equal(e, error);
+            });
+
+        });
+
+        specify("when they reject, and the generator has try.caught, it should continue working normally", function(){
+
+            return Promise.coroutine(function*(){
+                try {
+                    var a = yield fail(error);
+                }
+                catch (e) {
+                    return e;
+                }
+                assert.fail();
+
+            })().then(function(v){
+                assert.equal(v, error);
+            });
+
+        });
+
+        specify("when they fulfill but then throw, it should become rejection", function(){
+
+            return Promise.coroutine(function*(){
+                var a = yield get(3);
+                assert.equal(a, 3);
+                throw error;
+            })().then(assert.fail).then(assert.fail, function(e){
+                assert.equal(e, error);
+            });
+        });
+
+        specify("when they are already fulfilled, the yielded value should be returned asynchronously", function(){
+            var value;
+
+            var promise = Promise.coroutine(function*(){
+                yield Promise.resolve();
+                value = 2;
+            })();
+
+            value = 1;
+
+            return promise.then(function(){
+                assert.equal(value, 2);
+            });
+        });
+
+        specify("when they are already rejected, the yielded reason should be thrown asynchronously", function(){
+            var value;
+
+            var promise = Promise.coroutine(function*(){
+                try {
+                    yield Promise.reject();
+                }
+                catch (e) {
+                    value = 2;
+                }
+            })();
+
+            value = 1;
+
+            return promise.then(function(){
+                assert.equal(value, 2);
+            });
+        });
+    });
+
+    describe("yield loop", function(){
+
+        specify("should work", function(){
+            return Promise.coroutine(function* () {
+                var a = [1,2,3,4,5];
+
+                for (var i = 0, len = a.length; i < len; ++i) {
+                    a[i] = yield get(a[i] * 2);
+                }
+
+                return a;
+            })().then(function(arr){
+                assert.deepEqual([2,4,6,8,10], arr);
+            });
+        });
+
+        specify("inside yield should work", function(){
+            return Promise.coroutine(function *() {
+                var a = [1,2,3,4,5];
+
+                return yield Promise.all(a.map(function(v){
+                    return Promise.coroutine(function *() {
+                        return yield get(v*2);
+                    })();
+                }));
+            })().then(function(arr){
+                assert.deepEqual([2,4,6,8,10], arr);
+            });
+        });
+
+        specify("with simple map should work", function(){
+            return Promise.coroutine(function *() {
+                var a = [1,2,3,4,5];
+
+                return yield Promise.map(a, function(v){
+                    return Promise.cast(get(v*2));
+                });
+            })().then(function(arr){
+                assert.deepEqual([2,4,6,8,10], arr);
+            });
+        });
+
+    });
+
+    describe("when using coroutine as a method", function(){
+
+        function MyClass() {
+            this.goblins = 3;
+        }
+
+        MyClass.prototype.spawnGoblins = Promise.coroutine(function* () {
+            this.goblins = yield get(this.goblins+1);
+        });
+
+
+        specify("generator function's receiver should be the instance too", function() {
+            var a = new MyClass();
+            var b = new MyClass();
+
+            return Promise.join(a.spawnGoblins().then(function(){
+                return a.spawnGoblins()
+            }), b.spawnGoblins()).then(function(){
+                assert.equal(a.goblins, 5);
+                assert.equal(b.goblins, 4);
+            });
+
+        });
+    });
+});
+
+describe("Spawn", function() {
+    it("should work", function() {
+        return Promise.spawn(function*() {
+            return yield Promise.resolve(1);
+        }).then(function(value) {
+            assert.strictEqual(value, 1);
+        });
+    });
+    it("should return rejected promise when passed non function", function() {
+        return Promise.spawn({}).then(assert.fail, function(err) {
+            assert(err instanceof Promise.TypeError);
+        });
+    });
+});
+
+/*
+describe("custom yield handlers", function() {
+    specify("should work with timers", function() {
+        var n = 0;
+        Promise.coroutine.addYieldHandler(function(v) {
+            if (typeof v === "number") {
+                n = 1;
+                return Promise.resolve(n);
+            }
+        });
+
+
+        return Promise.coroutine(function*() {
+            return yield 50;
+        })().then(function(value) {
+            assert.equal(value, 1);
+            assert.equal(n, 1);
+        });
+    });
+
+    var _ = (function() {
+        var promise = null;
+        Promise.coroutine.addYieldHandler(function(v) {
+            if (v === void 0 && promise != null) {
+                return promise;
+            }
+            promise = null;
+        });
+        return function() {
+          var cb;
+          promise = Promise.fromNode(function(callback) {
+            cb = callback;
+          });
+          return cb;
+        };
+    })();
+
+    specify("Should work with callbacks", function(){
+        var callbackApiFunction = function(a, b, c, cb) {
+            setTimeout(function(){
+                cb(null, [a, b, c]);
+            }, 1);
+        };
+
+        return Promise.coroutine(function*() {
+            return yield callbackApiFunction(1, 2, 3, _());
+        })().then(function(result) {
+            assert(result.length === 3);
+            assert(result[0] === 1);
+            assert(result[1] === 2);
+            assert(result[2] === 3);
+        });
+    });
+
+    specify("should work with thunks", function(){
+        Promise.coroutine.addYieldHandler(function(v) {
+            if (typeof v === "function") {
+                var cb;
+                var promise = Promise.fromNode(function(callback) {
+                    cb = callback;
+                });
+                try { v(cb); } catch (e) { cb(e); }
+                return promise;
+            }
+        });
+
+        var thunk = function(a) {
+            return function(callback) {
+                setTimeout(function(){
+                    callback(null, a*a);
+                }, 1);
+            };
+        };
+
+        return Promise.coroutine(function*() {
+            return yield thunk(4);
+        })().then(function(result) {
+            assert(result === 16);
+        });
+    });
+
+    specify("individual yield handler", function() {
+        var dummy = {};
+        var yieldHandler = function(value) {
+            if (value === dummy) return Promise.resolve(3);
+        };
+        var coro = Promise.coroutine(function* () {
+            return yield dummy;
+        }, {yieldHandler: yieldHandler});
+
+        return coro().then(function(result) {
+            assert(result === 3);
+        });
+    });
+
+    specify("yield handler that throws", function() {
+        var dummy = {};
+        var unreached = false;
+        var err = new Error();
+        var yieldHandler = function(value) {
+            if (value === dummy) throw err;
+        };
+
+        var coro = Promise.coroutine(function* () {
+            yield dummy;
+            unreached = true;
+        }, {yieldHandler: yieldHandler});
+
+        return coro().then(assert.fail, function(e) {
+            assert.strictEqual(e, err);
+            assert(!unreached);
+        });
+    });
+
+    specify("yield handler is not a function", function() {
+        try {
+            Promise.coroutine.addYieldHandler({});
+        } catch (e) {
+            assert(e instanceof Promise.TypeError);
+            return;
+        }
+        assert.fail();
+    });
+});
+*/
+
+/*
+if (Promise.hasLongStackTraces()) {
+    describe("Long stack traces with coroutines as context", function() {
+        it("1 level", function() {
+            return Promise.coroutine(function* () {
+                yield Promise.delay(10);
+                throw new Error();
+            })().then(assert.fail, function(e) {
+                assertLongTrace(e, 1+1, [2]);
+            });
+        });
+        it("4 levels", function() {
+            var secondLevel = Promise.coroutine(function* () {
+                yield thirdLevel();
+            });
+            var thirdLevel = Promise.coroutine(function* () {
+                yield fourthLevel();
+            });
+            var fourthLevel = Promise.coroutine(function* () {
+                throw new Error();
+            });
+
+            return Promise.coroutine(function* () {
+                yield secondLevel();
+            })().then(assert.fail, function(e) {
+                assertLongTrace(e, 4+1, [2, 2, 2, 2]);
+            });
+        });
+    });
+}
+*/
+
+/*
+describe("Cancellation with generators", function() {
+    specify("input immediately cancelled", function() {
+        var cancelled = 0;
+        var finalled = 0;
+        var unreached = 0;
+
+        var p = new Promise(function(_, __, onCancel) {});
+        p.cancel();
+
+        var asyncFunction = Promise.coroutine(function* () {
+            try {
+                yield p;
+                unreached++;
+            } catch(e) {
+                if (e === Promise.coroutine.returnSentinel) throw e;
+                unreached++;
+            } finally {
+                yield Promise.resolve();
+                finalled++;
+            }
+            unreached++;
+        });
+
+        var resolve, reject;
+        var result = new Promise(function() {
+            resolve = arguments[0];
+            reject = arguments[1];
+        });
+
+        asyncFunction()
+            .then(reject, function(e) {
+                if(!(e instanceof Promise.CancellationError)) reject(new Error());
+            })
+            .lastly(function() {
+                finalled++;
+                resolve();
+            });
+
+        return result.then(function() {
+            return awaitLateQueue(function() {
+                assert.equal(2, finalled);
+                assert.equal(0, cancelled);
+                assert.equal(0, unreached);
+            });
+        });
+    });
+
+    specify("input eventually cancelled", function() {
+        var cancelled = 0;
+        var finalled = 0;
+        var unreached = 0;
+
+        var p = new Promise(function(_, __, onCancel) {});
+        var asyncFunction = Promise.coroutine(function* () {
+            try {
+                yield p;
+                unreached++;
+            } catch(e) {
+                if (e === Promise.coroutine.returnSentinel) throw e;
+                unreached++;
+            } finally {
+                yield Promise.resolve();
+                finalled++;
+            }
+            unreached++;
+        });
+
+        var resolve, reject;
+        var result = new Promise(function() {
+            resolve = arguments[0];
+            reject = arguments[1];
+        });
+
+        asyncFunction()
+            .then(reject, reject)
+            .lastly(function() {
+                finalled++;
+                resolve();
+            });
+
+        Promise.delay(1).then(function() {
+            p.cancel();
+        });
+
+        return result.then(function() {
+            return awaitLateQueue(function() {
+                assert.equal(2, finalled);
+                assert.equal(0, cancelled);
+                assert.equal(0, unreached);
+            });
+        });
+    });
+
+    specify("output immediately cancelled", function() {
+        var cancelled = 0;
+        var finalled = 0;
+        var unreached = 0;
+
+        var p = new Promise(function(_, __, onCancel) {
+            onCancel(function() {
+                cancelled++;
+            });
+        }).lastly(function() {
+            finalled++;
+        });
+
+        var asyncFunction = Promise.coroutine(function* () {
+            try {
+                yield p;
+                unreached++;
+            } catch(e) {
+                if (e === Promise.coroutine.returnSentinel) throw e;
+                unreached++;
+            } finally {
+                yield Promise.resolve()
+                finalled++;
+            }
+            unreached++;
+        });
+
+        var resolve, reject;
+        var result = new Promise(function() {
+            resolve = arguments[0];
+            reject = arguments[1];
+        });
+
+        var output = asyncFunction()
+            .then(reject, reject)
+            .lastly(function() {
+                finalled++;
+                resolve();
+            });
+
+        output.cancel();
+
+        return result.then(function() {
+            return awaitLateQueue(function() {
+                assert.equal(3, finalled);
+                assert.equal(1, cancelled);
+                assert.equal(0, unreached);
+            });
+        });
+    });
+
+    specify("output eventually cancelled", function() {
+        var cancelled = 0;
+        var finalled = 0;
+        var unreached = 0;
+
+        var p = new Promise(function(_, __, onCancel) {
+            onCancel(function() {
+                cancelled++;
+            });
+        }).lastly(function() {
+            finalled++;
+        });
+
+        var asyncFunction = Promise.coroutine(function* () {
+            try {
+                yield p;
+                unreached++;
+            } catch(e) {
+                if (e === Promise.coroutine.returnSentinel) throw e;
+                unreached++;
+            } finally {
+                yield Promise.resolve()
+                finalled++;
+            }
+            unreached++;
+        });
+
+        var resolve, reject;
+        var result = new Promise(function() {
+            resolve = arguments[0];
+            reject = arguments[1];
+        });
+
+        var output = asyncFunction()
+            .then(reject, reject)
+            .lastly(function() {
+                finalled++;
+                resolve();
+            });
+
+        Promise.delay(1).then(function() {
+            output.cancel();
+        });
+
+        return result.then(function() {
+            return awaitLateQueue(function() {
+                assert.equal(3, finalled);
+                assert.equal(1, cancelled);
+                assert.equal(0, unreached);
+            });
+        });
+    });
+
+
+    specify("finally block runs before finally handler", function(done) {
+        var finallyBlockCalled = false;
+        var asyncFn = Promise.coroutine(function* () {
+            try {
+                yield Promise.delay(100);
+            } finally {
+                yield Promise.delay(100);
+                finallyBlockCalled = true;
+            }
+        });
+        var p = asyncFn();
+        Promise.resolve().then(function() {
+            p.cancel();
+        });
+        p.finally(function() {
+            assert.ok(finallyBlockCalled, "finally block should have been called before finally handler");
+            done();
+        }).catch(done);
+    });
+});
+*/

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -8,7 +8,9 @@ const Promise = require("../promise.js");
 testUtils.addDeferred(Promise);
 Promise.TypeError = TypeError;
 
-//original tests
+// original tests. untouched, but some commented out
+// from: https://github.com/petkaantonov/bluebird/blob/master/test/mocha/generator.js
+
 function get(arg) {
     return {
         then: function(ful, rej) {


### PR DESCRIPTION
Brought in bluebird's tests. All tests now pass except for:

* Not running tests for Promise.coroutine.addyieldhandler
* Not running tests for Cancelling coroutines.

```
  Promise.coroutine
    thenables
      ✓ when they fulfill, the yielded value should be that fulfilled value
      ✓ when they reject, and the generator doesn't have try.caught, it should immediately reject the promise
      ✓ when they reject, and the generator has try.caught, it should continue working normally
      ✓ when they fulfill but then throw, it should become rejection
      ✓ when they are already fulfilled, the yielded value should be returned asynchronously
      ✓ when they are already rejected, the yielded reason should be thrown asynchronously
    yield loop
      ✓ should work
      ✓ inside yield should work
      ✓ with simple map should work
    when using coroutine as a method
      ✓ generator function's receiver should be the instance too

  Spawn
    ✓ should work
    ✓ should return rejected promise when passed non function
```