### PR TITLE
Filtered / Typed .catch()

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Test Debug",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "npm",
+            "windows": {
+                "runtimeExecutable": "npm.cmd"
+            },
+            "runtimeArgs": [
+                "run-script", "test-debug"
+            ],
+            "port": 5858
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "test": "tests"
     },
     "scripts": {
-        "test": "mocha tests"
+        "test": "mocha tests",
+        "test-debug": "mocha --debug-brk tests"
     },
     "repository": {
         "type": "git",

--- a/promise.js
+++ b/promise.js
@@ -20,7 +20,7 @@ require('./promiseFns/reduce')(Bluebird);
 require('./promiseFns/throw')(Bluebird);
 require('./promiseFns/catchReturn')(Bluebird);
 require('./promiseFns/catchThrow')(Bluebird);
-require('./promiseFns/caught')(Bluebird);
+require('./promiseFns/catch')(Bluebird);
 require('./promiseFns/coroutine')(Bluebird);
 require('./promiseFns/cast')(Bluebird);
 require('./promiseFns/fromCallback')(Bluebird);

--- a/promiseFns/catch.js
+++ b/promiseFns/catch.js
@@ -1,0 +1,54 @@
+module.exports = (Bluebird) => {
+    // think: super.catch
+    const super_catch = Promise.prototype.catch;
+
+    Bluebird.prototype.catch = Bluebird.prototype.caught = function catchFn(fn) {
+        if (arguments.length > 1) {
+            const filters = Array.prototype.slice.call(arguments, 0, -1);
+            fn = arguments[arguments.length - 1];
+
+            return super_catch.call(this, filterCatch(filters, fn));
+        }
+        else {
+            return super_catch.call(this, fn);
+        }
+    };
+
+    function filterCatch(filters, fn) {
+        return (error) => {
+            for (const filter of filters) {
+                if (testFilter(filter, error)) {
+                    return fn(error); //TODO: deal with Bluebird.bind() here?
+                }
+            }
+
+            return Bluebird.reject(error);
+        };
+    }
+};
+
+const FILTER_CONFIGS = [
+    { // Error contructor
+        filterTest: (t, error) => t && (t === Error || t.prototype instanceof Error),
+        predicate: (t, error) => error instanceof t
+    },
+    { // function
+        filterTest: (t, error) => typeof t === 'function',
+        predicate: (fn, error) => fn(error)
+    },
+    { // else: Object shallow compare w/
+        // note: we test the thrown error, not the filter argument as in previous filterTest()s. This is what bluebird does.
+        filterTest: (o, error) => typeof error === 'function' || (typeof error === 'object' && error !== null),
+        // To match Bluebird's behavior, uses ==, not === intentionally
+        predicate: (filter, error) => !Object.keys(filter).some(key => filter[key] != error[key])
+    }
+];
+
+function testFilter(filterArgument, error) {
+    // get the right predicate function for the type of filter the user supplied.
+    const filterConfig = FILTER_CONFIGS.find(filterConfig => filterConfig.filterTest(filterArgument, error));
+    const { predicate } = filterConfig || {};
+
+    // If not filters are valid, we jist return false. It's not an exception
+    return predicate && predicate(filterArgument, error);
+}

--- a/promiseFns/caught.js
+++ b/promiseFns/caught.js
@@ -1,3 +1,0 @@
-module.exports = (Bluebird) => {
-    Bluebird.prototype.caught = Promise.prototype.catch;
-};

--- a/tests/catchFilter.js
+++ b/tests/catchFilter.js
@@ -1,0 +1,420 @@
+"use strict";
+
+var assert = require("assert");
+var testUtils = require("./helpers/util.js");
+const Promise = require("../promise.js");
+
+testUtils.addDeferred(Promise);
+
+var CustomError = function(){};
+
+CustomError.prototype = new Error();
+
+var predicateFilter = function(e) {
+    return (/invalid/).test(e.message);
+}
+
+function BadError(msg) {
+    this.message = msg;
+    return this;
+}
+
+function predicatesUndefined(e) {
+    return e === void 0;
+}
+
+function predicatesPrimitiveString(e) {
+    return /^asd$/.test(e);
+}
+
+var token = {};
+var returnToken = function() {
+    return token;
+};
+
+var assertToken = function(val) {
+    assert.strictEqual(token, val);
+};
+
+describe("A promise handler that throws a TypeError must be caught", function() {
+
+    specify("in a middle.caught filter", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            a.b.c.d()
+        }).then(assert.fail).caught(SyntaxError, function(e){
+            assert.fail();
+        }).caught(Promise.TypeError, returnToken)
+        .then(assertToken);
+    });
+
+
+    specify("in a generic.caught filter that comes first", function() {
+        var a = Promise.defer();
+
+        a.fulfill(3);
+        return a.promise.then(function(){
+            a.b.c.d()
+        }).then(assert.fail, returnToken).caught(SyntaxError, function(e){
+            assert.fail();
+        }).caught(Promise.TypeError, function(e){
+            assert.fail();
+        }).then(assertToken);
+
+    });
+
+    specify("in an explicitly generic.caught filter that comes first", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            a.b.c.d()
+        })
+        .then(assert.fail)
+        .caught(Error, returnToken)
+        .caught(SyntaxError, assert.fail)
+        .caught(Promise.TypeError, assert.fail)
+        .then(assertToken);
+    });
+
+    specify("in a specific handler after thrown in generic", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            a.b.c.d()
+        }).then(assert.fail, function(e){
+            throw e
+        }).caught(SyntaxError, assert.fail)
+        .then(assert.fail)
+        .caught(Promise.TypeError, returnToken)
+        .then(assertToken);
+
+
+    });
+
+
+    specify("in a multi-filter handler", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            a.b.c.d()
+        })
+        .then(assert.fail)
+        .caught(SyntaxError, TypeError, returnToken)
+        .then(assertToken);
+    });
+
+
+    specify("in a specific handler after non-matching multi.caught handler", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            a.b.c.d()
+        })
+        .then(assert.fail)
+        .caught(SyntaxError, CustomError, assert.fail)
+        .caught(Promise.TypeError, returnToken)
+        .then(assertToken)
+    });
+
+});
+
+
+describe("A promise handler that throws a custom error", function() {
+
+    specify("Is filtered if inheritance was done even remotely properly", function() {
+        var a = Promise.defer();
+        var b = new CustomError();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw b;
+        })
+        .then(assert.fail)
+        .caught(SyntaxError, assert.fail)
+        .caught(Promise.TypeError, assert.fail)
+        .caught(CustomError, function(e){
+            assert.equal(e, b);
+            return token;
+        })
+        .then(assertToken);
+
+
+    });
+
+    specify("Is filtered along with built-in errors", function() {
+        var a = Promise.defer();
+        var b = new CustomError();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw b;
+        })
+        .then(assert.fail)
+        .caught(Promise.TypeError, SyntaxError, CustomError, returnToken)
+        .caught(assert.fail)
+        .then(assertToken)
+    });
+
+    specify("Throws after matched type handler throws", function() {
+        var err = new Promise.TypeError();
+        var err2 = new Error();
+        return Promise.reject(err).caught(Promise.TypeError, function() {
+            throw err2;
+        }).then(assert.fail, function(e) {
+            assert.strictEqual(err2, e);
+        });
+    });
+});
+
+describe("A promise handler that throws a CustomError must be caught", function() {
+    specify("in a middle.caught filter", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        })
+        .caught(SyntaxError, assert.fail)
+        .caught(CustomError, returnToken)
+        .then(assertToken);
+    });
+
+
+    specify("in a generic.caught filter that comes first", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        }).then(assert.fail, returnToken)
+        .caught(SyntaxError, assert.fail)
+        .caught(CustomError, assert.fail)
+        .then(assertToken)
+    });
+
+    specify("in an explicitly generic.caught filter that comes first", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        })
+        .caught(Error, returnToken)
+        .caught(SyntaxError, assert.fail)
+        .caught(CustomError, assert.fail)
+        .then(assertToken);
+    });
+
+    specify("in a specific handler after thrown in generic", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        }).then(assert.fail, function(e){
+            throw e
+        })
+        .caught(SyntaxError, assert.fail)
+        .caught(CustomError, returnToken)
+        .then(assertToken);
+
+    });
+
+
+    specify("in a multi-filter handler", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        })
+        .caught(SyntaxError, CustomError, returnToken)
+        .then(assertToken)
+
+    });
+
+
+    specify("in a specific handler after non-matching multi.caught handler", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+
+        return a.promise.then(function(){
+            throw new CustomError()
+        })
+        .caught(SyntaxError, TypeError, assert.fail)
+        .caught(CustomError, returnToken)
+        .then(assertToken);
+    });
+
+});
+
+describe("A promise handler that is caught in a filter", function() {
+
+    specify("is continued normally after returning a promise in filter", function() {
+         var a = Promise.defer();
+         var c = Promise.defer();
+         var b = new CustomError();
+         a.fulfill(3);
+         setTimeout(function(){
+             c.fulfill(3);
+         }, 1);
+         return a.promise.then(function(){
+             throw b;
+         }).caught(SyntaxError, function(e){
+            assert.fail();
+         }).caught(Promise.TypeError, function(e){
+            assert.fail();
+         }).caught(CustomError, function(e){
+            assert.equal(e, b);
+            return c.promise.thenReturn(token);
+         }).then(assertToken, assert.fail, assert.fail);
+    });
+
+    specify("is continued normally after returning a promise in original handler", function() {
+         var a = Promise.defer();
+         var c = Promise.defer();
+         a.fulfill(3);
+         setTimeout(function(){
+             c.fulfill(3);
+         }, 1);
+        return a.promise.then(function(){
+             return c.promise;
+         }).caught(SyntaxError, function(e){
+            assert.fail();
+         }).caught(Promise.TypeError, function(e){
+            assert.fail();
+         }).caught(CustomError, function(e){
+            assert.fail();
+         });
+
+    });
+});
+
+describe("A promise handler with a predicate filter", function() {
+
+    specify("will catch a thrown thing matching the filter", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw new Error("horrible invalid error string");
+        }).caught(predicateFilter, returnToken)
+        .then(assertToken);
+
+    });
+    specify("will NOT catch a thrown thing not matching the filter", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw new Error("horrible valid error string");
+        }).caught(predicateFilter, function(e){
+            assert.fail();
+        }).then(assert.fail, function(){})
+    });
+
+    specify("will assert.fail when a predicate is a bad error class", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw new Error("horrible custom error");
+        }).caught(BadError, function(e){
+            assert.fail();
+        }).then(assert.fail, returnToken)
+        .then(assertToken);
+
+    });
+
+    specify("will catch a thrown undefiend", function(){
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw void 0;
+        }).caught(function(e) { return false }, function(e){
+            assert.fail();
+        }).caught(predicatesUndefined, returnToken)
+        .then(assertToken);
+
+    });
+
+    specify("will catch a thrown string", function(){
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw "asd";
+        }).caught(function(e) { return false }, function(e){
+            assert.fail();
+        }).caught(predicatesPrimitiveString, returnToken)
+        .then(assertToken);
+
+    });
+
+    specify("will assert.fail when a predicate throws", function() {
+        var a = Promise.defer();
+        a.fulfill(3);
+        return a.promise.then(function(){
+            throw new CustomError("error happens");
+        }).then(assert.fail, function(e) { return e.f.g; }, function(e){
+            assert.fail();
+        }).caught(TypeError, returnToken)
+        .then(assertToken);
+    });
+});
+
+describe("object property predicates", function() {
+    specify("matches 1 property loosely", function() {
+        var e = new Error();
+        e.code = "3";
+        return Promise.resolve()
+            .then(function() {
+                throw e;
+            })
+            .caught({code: 3}, function(err) {
+                assert.equal(e, err);
+            });
+    });
+
+    specify("matches 2 properties loosely", function() {
+        var e = new Error();
+        e.code = "3";
+        e.code2 = "3";
+        return Promise.resolve()
+            .then(function() {
+                throw e;
+            })
+            .caught({code: 3, code2: 3}, function(err) {
+                assert.equal(e, err);
+            });
+    });
+
+    specify("doesn't match inequal properties", function() {
+        var e = new Error();
+        e.code = "3";
+        e.code2 = "4";
+        return Promise.resolve()
+            .then(function() {
+                throw e;
+            })
+            .caught({code: 3, code2: 3}, function(err) {
+                assert.fail();
+            })
+            .caught(function(v) {return v === e}, function() {});
+    });
+
+    specify("doesn't match primitives even if the property matches", function() {
+        var e = "string";
+        var length = e.length;
+        return Promise.resolve()
+            .then(function() {
+                throw e;
+            })
+            .caught({length: length}, function(err) {
+                assert.fail();
+            })
+            .caught(function(v) {return typeof v === "string"}, function(err) {
+                
+                assert.equal(e, err);
+            });
+    });
+});


### PR DESCRIPTION
- All filtered catch tests from bluebird passing
- May need trivial change if/when we implement .bind()
- Included a .vscode/launch.json as I'm converting to vscode and played with it's debugging.