### PR TITLE
Update mapSeries.js

### DIFF
--- a/promiseFns/mapSeries.js
+++ b/promiseFns/mapSeries.js
@@ -3,7 +3,7 @@ module.exports = (Bluebird) => {
       return Bluebird.resolve((async () => { 
         const promises = await this;
         const length = promises.length;
-        let ret = Array(length);
+        let ret = [];
         
         for(let index = 0; index <= promises.length-1; index++){
           const value = await iterator(await promises[index], index, length);


### PR DESCRIPTION
Here an array is being created with a set length:

https://github.com/benjamingr/bluebird-api/blob/1f02a97e30037943a2952449615fe6bf7ef28b39/promiseFns/mapSeries.js#L6

The concat function adds an item to array and increments length. Either ret[index] = value should be used or the length of the array should be initialized to 0.

https://github.com/benjamingr/bluebird-api/blob/1f02a97e30037943a2952449615fe6bf7ef28b39/promiseFns/mapSeries.js#L10